### PR TITLE
Remove a comma to fix a bug

### DIFF
--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -21,7 +21,7 @@
 </div>
 <div class="container">
   <div class="alert alert-info text-center" role="alert">
-    To deploy your own copy, and learn the fundamentals of the Heroku platform, head over to the <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs" class="alert-link">Getting Started with Node on Heroku</a> tutorial.
+    To deploy your own copy and learn the fundamentals of the Heroku platform, head over to the <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs" class="alert-link">Getting Started with Node on Heroku</a> tutorial.
   </div>
   <hr>
   <div class="row">


### PR DESCRIPTION
This pretends that a comma was causing a bug, and removes it.  I expect the following things to happen:

1) I expect a review app to be created on Heroku
2) I expect the event of creating the review app to be spoken into the channel #cd-practice in the tikaroworkspace.slack.com chat room.